### PR TITLE
Azure Firewall subnet name must be AzureFirewallSubnet

### DIFF
--- a/custom.json
+++ b/custom.json
@@ -142,7 +142,7 @@
       "allowed_values": {
          "azure-appgateway": "Application Gateway",
          "azure-vpngateway": "VPN Gateway",
-         "azure-firewall": "Azure Firewall",
+         "AzureFirewallSubnet": "Azure Firewall",
          "azure-rediscache": "Redis Cache",
          "azure-sqldatabase": "Azure SQL Database",
          "azure-containers": "Azure Container Instance",


### PR DESCRIPTION
Azure Firewall subnet name must be AzureFirewallSubnet. Reference - https://docs.microsoft.com/en-us/azure/firewall/tutorial-firewall-deploy-portal#create-a-vnet